### PR TITLE
Disable warnings about non-camel case types.

### DIFF
--- a/freetype.rs
+++ b/freetype.rs
@@ -7,6 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
 #[allow(non_uppercase_statics)];
 
 use std::libc::*;

--- a/tt_os2.rs
+++ b/tt_os2.rs
@@ -7,6 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
+
 use freetype::{FT_UShort, FT_Short, FT_ULong, FT_Byte};
 
 pub struct TT_OS2 {


### PR DESCRIPTION
I don't think there's much reason to follow Rust's style guidelines in FFI code.
