### PR TITLE
Update to the last Rust.

### DIFF
--- a/freetype.rc
+++ b/freetype.rc
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[crate_id = "github.com/mozilla-servo/rust-freetype#freetype:0.1"];
-#[crate_type = "lib"];
-#[crate_type = "dylib"];
-#[crate_type = "rlib"];
+#![crate_id = "github.com/mozilla-servo/rust-freetype#freetype:0.1"]
+#![crate_type = "lib"]
+#![crate_type = "dylib"]
+#![crate_type = "rlib"]
 
-#[feature(globs)];
+#![feature(globs)]
 
 extern crate std;
 extern crate libc;

--- a/freetype.rs
+++ b/freetype.rs
@@ -7,8 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[allow(non_camel_case_types)];
-#[allow(non_uppercase_statics)];
+#![allow(non_camel_case_types)]
+#![allow(non_uppercase_statics)]
 
 use libc::*;
 

--- a/tt_os2.rs
+++ b/tt_os2.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[allow(non_camel_case_types)];
+#![allow(non_camel_case_types)]
 
 use freetype::{FT_UShort, FT_Short, FT_ULong, FT_Byte};
 


### PR DESCRIPTION
`libc` is now an extern crate.
Attributes' syntax changed from `#[foo];` to `#![foo]`
