### PR TITLE
Make attributes on all pub structs public

### DIFF
--- a/freetype.rs
+++ b/freetype.rs
@@ -480,11 +480,11 @@ pub static FT_SIZE_REQUEST_TYPE_MAX: u32 = 5_u32;
 pub type FT_Size_Request_Type = enum_FT_Size_Request_Type_;
 
 pub struct struct_FT_Size_RequestRec_ {
-    _type: FT_Size_Request_Type,
-    width: FT_Long,
-    height: FT_Long,
-    horiResolution: FT_UInt,
-    vertResolution: FT_UInt,
+    pub _type: FT_Size_Request_Type,
+    pub width: FT_Long,
+    pub height: FT_Long,
+    pub horiResolution: FT_UInt,
+    pub vertResolution: FT_UInt,
 }
 
 pub type FT_Size_RequestRec = struct_FT_Size_RequestRec_;


### PR DESCRIPTION
I've been having some problems after my latest upgrade, since a lot of struct attributes that were public before are private now (due to the changes in Rust). To solve this problem, I went ahead and made all attributes on all public structs public.

I'm not sure if this is a 100% correct, since at least some of the FreeType functions look like they access data from structs, but decided to go ahead anyway, for the following reasons:
- The attributes were public before the change in Rust, so nothing really changes (although I haven't checked the history in detail, there might have been private attributes before).
- Since these are low-level bindings to a C library, I don't think restricting access is the right thing to do anyway.
