### PR TITLE
Make the dependency on servo-freetype-sys optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
 
 name = "freetype"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Servo Project Developers"]
 documentation = "http://doc.servo.org/freetype/"
 
-[lib]
+[features]
+default = ["servo-freetype-sys"]
 
+[lib]
 name = "freetype"
 crate-type = ["rlib"]
 
 [dependencies]
-servo-freetype-sys = "4.0.2"
+servo-freetype-sys = { version = "4.0.2", optional = true }
 libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
+#[cfg(feature = "servo-freetype-sys")]
 extern crate freetype_sys;
 extern crate libc;
 


### PR DESCRIPTION
Some users of rust-freetype don't actually need servo-freetype-sys because they are getting the freetype library from elsewhere (e.g. firefox already has its own copy of freetype in-tree). For those users I'd like to make this dependency an optional feature. It is enabled by default for backwards-compatibility; I'm not sure who all is using rust-freetype but if they're relying on it pulling in servo-freetype-sys I don't want to break that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-freetype/43)
<!-- Reviewable:end -->
