### PR TITLE
Add necessary metadata to cargo so we can publish this crate again.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
-
+description = "Bindings for Freetype used by Servo"
+license = "Apache-2.0 / MIT"
 name = "freetype"
 version = "0.1.2"
 authors = ["The Servo Project Developers"]


### PR DESCRIPTION
The lack of metadata is a hard error now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-freetype/44)
<!-- Reviewable:end -->
