### PR TITLE
Fix FFI of FT_Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Bindings for Freetype used by Servo"
 license = "Apache-2.0 / MIT"
 name = "freetype"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The Servo Project Developers"]
 documentation = "http://doc.servo.org/freetype/"
 repository = "https://github.com/servo/rust-freetype"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,16 +20,11 @@
 extern crate freetype_sys;
 extern crate libc;
 
-/// A wrapper over FT_Error so we can add convenience methods on it.
-#[repr(C)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct FT_Error(pub ::std::os::raw::c_int);
+pub type FT_Error = ::std::os::raw::c_int;
 
-impl FT_Error {
-    #[inline]
-    pub fn succeeded(&self) -> bool {
-        self.0 == freetype::FT_Err_Ok as ::std::os::raw::c_int
-    }
+#[inline]
+pub fn succeeded(error: FT_Error) -> bool {
+    error == freetype::FT_Err_Ok as FT_Error
 }
 
 #[allow(improper_ctypes)] // https://github.com/rust-lang/rust/issues/34798


### PR DESCRIPTION
Address #50. It is not ideal way to address the problem. But we could not use #[repr(transparent)] on stable channel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-freetype/51)
<!-- Reviewable:end -->
