### PR TITLE
Fix the incorrect definition of the OS/2 table.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Bindings for Freetype used by Servo"
 license = "Apache-2.0 / MIT"
 name = "freetype"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The Servo Project Developers"]
 documentation = "http://doc.servo.org/freetype/"
 repository = "https://github.com/servo/rust-freetype"

--- a/src/tt_os2.rs
+++ b/src/tt_os2.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use freetype::{FT_UShort, FT_Short, FT_ULong, FT_Byte};
+use freetype::{FT_Char, FT_UShort, FT_Short, FT_ULong, FT_Byte};
 
 #[repr(C)]
 pub struct TT_OS2 {
@@ -34,6 +34,17 @@ pub struct TT_OS2 {
     pub ulUnicodeRange2: FT_ULong, /* Bits 32-63  */
     pub ulUnicodeRange3: FT_ULong, /* Bits 64-95  */
     pub ulUnicodeRange4: FT_ULong, /* Bits 96-127 */
+
+    pub achVendID: [FT_Char; 4],
+
+    pub fsSelection: FT_UShort,
+    pub usFirstCharIndex: FT_UShort,
+    pub usLastCharIndex: FT_UShort,
+    pub sTypoAscender: FT_Short,
+    pub sTypoDescender: FT_Short,
+    pub sTypoLineGap: FT_Short,
+    pub usWinAscent: FT_UShort,
+    pub usWinDescent: FT_UShort,
 
     /* only version 1 tables */
 


### PR DESCRIPTION
See: https://docs.microsoft.com/en-us/typography/opentype/spec/os2

r? @mbrubeck

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-freetype/53)
<!-- Reviewable:end -->
