### PR TITLE
Update freetype-sys to 0.19 and release version 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Bindings for Freetype used by Servo"
 license = "Apache-2.0 / MIT"
 name = "freetype"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["The Servo Project Developers"]
 documentation = "https://doc.servo.org/freetype/"
 repository = "https://github.com/servo/rust-freetype"
@@ -15,5 +15,5 @@ name = "freetype"
 crate-type = ["rlib"]
 
 [dependencies]
-freetype-sys = { version = "0.13.0", optional = true }
+freetype-sys = { version = "0.19.0", optional = true }
 libc = "0.2"


### PR DESCRIPTION
This is required to update harfbuzz, core-foundation, winit, and egui in
Servo.
