### PR TITLE
Rename `master` branch to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - auto
-      - try
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
This also removes branches that serve as integration points with homu (replaced by GitHub Actions).