### PR TITLE
Update freetype-sys and bump version to v0.7.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Bindings for Freetype used by Servo"
 license = "Apache-2.0 / MIT"
 name = "freetype"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["The Servo Project Developers"]
 documentation = "https://doc.servo.org/freetype/"
 repository = "https://github.com/servo/rust-freetype"
@@ -15,5 +15,5 @@ name = "freetype"
 crate-type = ["rlib"]
 
 [dependencies]
-freetype-sys = { version = "0.19.0", optional = true }
+freetype-sys = { version = "0.20.1", optional = true }
 libc = "0.2"


### PR DESCRIPTION
Update freetype-sys to v0.20.1 for an OpenHarmony build fix.